### PR TITLE
Game chat

### DIFF
--- a/keymap.c
+++ b/keymap.c
@@ -109,6 +109,10 @@ enum {
 #define TD_LANG KC_GRV
 #endif
 
+bool gam_ent_on;
+void gam_ent_enable(void);
+void gam_ent_disable(void);
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 
@@ -495,7 +499,53 @@ bool oled_task_user(void) {
 
 #endif
 
+
+// CAPS_WORD: A "smart" Caps Lock key that only capitalizes the next identifier you type
+// and then toggles off Caps Lock automatically when you're done.
+void gam_ent_enable(void) {
+    gam_ent_on = true;
+    
+}
+
+void gam_ent_disable(void) {
+    gam_ent_on = false;
+    layer_invert(_GAMING);
+    
+}
+
+static void process_gam_ent(uint16_t keycode, const keyrecord_t *record) {
+    // Update caps word state
+    if (gam_ent_on) {
+
+        switch (keycode) {
+            // Keycodes to shift
+            case KC_A ... KC_Z:
+            case KC_MINS:
+            case KC_BSPC:
+            case KC_UNDS:
+            case KC_LPRN:
+            case KC_RPRN:
+                // When enter is pressed, returns to game layer
+                if (record->event.pressed) {
+                    tap_code(KC_ENT);
+                    gam_ent_disable();
+                }
+                break;
+        /*    default:
+                // Any other keycode should automatically return to game
+                if (record->event.pressed) {                
+                    gam_ent_disable();
+                }
+                break;*/
+        }
+    }
+}
+
+
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+        process_gam_ent(keycode, record);
+
+
     switch (keycode) {
          
         case KC_COLEMAKDH:
@@ -504,14 +554,12 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             }
             return false;
 
-        
         case KC_GAMING:
             if (record->event.pressed) {
                 layer_invert(_GAMING);
             }
             return false;
         
-
         case KC_NUMPAD:
             if (record->event.pressed) {
                 layer_on(_NUMPAD);
@@ -519,6 +567,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 layer_off(_NUMPAD);
             }
             return false;
+
         case KC_NAV:
             if (record->event.pressed) {
                 layer_on(_NAV);
@@ -526,6 +575,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 layer_off(_NAV);
             }
             return false;
+
         case KC_ADJUST:
             if (record->event.pressed) {
                 layer_on(_ADJUST);
@@ -545,16 +595,17 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         case GAM_ENT:
             // Toggle `gam_ent_on`
             if (record->event.pressed) {
-                tap_code(KC_ENT);
-                /*
-                if (gam_ent_on) {
+                tap_code(KC_ENT);   
+                layer_invert(_GAMING);
+            
+            /*    if (gam_ent_on) {
                     gam_ent_disable();
                     return false;
-                } else {
+                } else {*/
                     gam_ent_enable();
-                    return false;
-                }
-                */
+            /*        return false;
+                }*/
+                
             }
             return false;
             break;
@@ -611,48 +662,3 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
 
 #endif
 
-/*
-// CAPS_WORD: A "smart" Caps Lock key that only capitalizes the next identifier you type
-// and then toggles off Caps Lock automatically when you're done.
-void gam_ent_enable(void) {
-    gam_ent_on = true;
-    layer_invert(_GAMING);
-    }
-}
-
-void gam_ent_disable(void) {
-    gam_ent_on = false;
-    layer_invert(_GAMING);
-    }
-}
-
-static void process_caps_word(uint16_t keycode, const keyrecord_t *record) {
-    // Update caps word state
-    if (gam_ent_on) {
-
-        switch (keycode) {
-            // Keycodes to shift
-            case KC_A ... KC_Z:
-
-            case KC_MINS:
-            case KC_BSPC:
-            case KC_UNDS:
-            case KC_LPRN:
-            case KC_RPRN:
-                // If chording mods, disable caps word
-                if (record->event.pressed) {
-                    tap_code(KC_ENT);
-                    gam_ent_disable();
-                }
-                break;
-            default:
-                // Any other keycode should automatically disable caps
-                if (record->event.pressed) {                
-                    gam_ent_disable();
-                }
-                break;
-        }
-    }
-}
-
-*/

--- a/keymap.c
+++ b/keymap.c
@@ -166,7 +166,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   //|------+-------+--------+--------+--------+------|  ===  |   |  ===  |--------+-------+--------+--------+--------+---------| 
   KC_LALT  ,KC_B,   KC_Z,    KC_X,    KC_C,    KC_V,   XXXXXXX,   XXXXXXX,KC_N,    KC_M,   KC_COMM, KC_DOT,  KC_QUOT, KC_SLSH, \
   //|------+-------+--------+--------+--------+------|  ===  |   |  ===  |--------+-------+--------+--------+--------+---------| 
-                 XXXXXXX, KC_NUMPAD,KC_LCTRL, KC_SPC,  KC_ENT,   KC_BSPC, KC_LSFT,  XXXXXXX,  KC_NAV, XXXXXXX \
+                 XXXXXXX, KC_NUMPAD,KC_LCTRL, KC_SPC,  GAM_ENT,   KC_BSPC, KC_LSFT,  XXXXXXX,  KC_NAV, XXXXXXX \
   //            \--------+--------+--------+---------+-------|   |--------+---------+--------+---------+-------/  
 ),
 
@@ -223,7 +223,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   //|------+-------+--------+--------+--------+------|  ===  |   |  ===  |--------+-------+--------+--------+--------+---------|
   _______,  XXXXXXX, KC_HOME, XXXXXXX, KC_END, XXXXXXX,_______,    _______,XXXXXXX, KC_MPRV, KC_MPLY, KC_MNXT, XXXXXXX, XXXXXXX,
   //|------+-------+--------+--------+--------+------|  ===  |   |  ===  |--------+-------+--------+--------+--------+---------|
-                 _______, _______, _______, _______, _______,     _______, _______, _______, XXXXXXX, _______
+                 _______,KC_SWITCH, _______, _______, _______,     _______, _______, _______, XXXXXXX, _______
   //            \--------+--------+--------+---------+-------|   |--------+---------+--------+---------+-------/
 ),
 /* ADJUST
@@ -272,7 +272,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   // layer switcher
 [_SWITCH] = LAYOUT(
   //,------------------------------------------------.                    ,---------------------------------------------------.
-  _______, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,                   XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,XXXXXXX, XXXXXXX,
+  _______,KC_COLEMAKDH,KC_GAMING, XXXXXXX, XXXXXXX, XXXXXXX,                   XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,XXXXXXX, XXXXXXX,
   //|------+-------+--------+--------+--------+------|                   |--------+-------+--------+--------+--------+---------|
   RESET , XXXXXXX, XXXXXXX, XXXXXXX,XXXXXXX, XXXXXXX, 	                  KC_NO,   XXXXXXX, KC_NO,   KC_NO,   KC_NO,   EEP_RST,
   //|------+-------+--------+--------+--------+------|                   |--------+-------+--------+--------+--------+---------|
@@ -504,11 +504,13 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             }
             return false;
 
-        //case KC_GAMING:
-        //    if (record->event.pressed) {
-        //        set_single_persistent_default_layer(_GAMING);
-        //    }
-        //    return false;/
+        
+        case KC_GAMING:
+            if (record->event.pressed) {
+                layer_invert(_GAMING);
+            }
+            return false;
+        
 
         case KC_NUMPAD:
             if (record->event.pressed) {
@@ -541,11 +543,21 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             return false;
 
         case GAM_ENT:
+            // Toggle `gam_ent_on`
             if (record->event.pressed) {
                 tap_code(KC_ENT);
-                layer_invert(_GAMING);
+                /*
+                if (gam_ent_on) {
+                    gam_ent_disable();
+                    return false;
+                } else {
+                    gam_ent_enable();
+                    return false;
+                }
+                */
             }
             return false;
+            break;
 
         case KC_D_MUTE:
             if (record->event.pressed) {
@@ -598,3 +610,49 @@ bool encoder_update_user(uint8_t index, bool clockwise) {
 }
 
 #endif
+
+/*
+// CAPS_WORD: A "smart" Caps Lock key that only capitalizes the next identifier you type
+// and then toggles off Caps Lock automatically when you're done.
+void gam_ent_enable(void) {
+    gam_ent_on = true;
+    layer_invert(_GAMING);
+    }
+}
+
+void gam_ent_disable(void) {
+    gam_ent_on = false;
+    layer_invert(_GAMING);
+    }
+}
+
+static void process_caps_word(uint16_t keycode, const keyrecord_t *record) {
+    // Update caps word state
+    if (gam_ent_on) {
+
+        switch (keycode) {
+            // Keycodes to shift
+            case KC_A ... KC_Z:
+
+            case KC_MINS:
+            case KC_BSPC:
+            case KC_UNDS:
+            case KC_LPRN:
+            case KC_RPRN:
+                // If chording mods, disable caps word
+                if (record->event.pressed) {
+                    tap_code(KC_ENT);
+                    gam_ent_disable();
+                }
+                break;
+            default:
+                // Any other keycode should automatically disable caps
+                if (record->event.pressed) {                
+                    gam_ent_disable();
+                }
+                break;
+        }
+    }
+}
+
+*/

--- a/keymap.c
+++ b/keymap.c
@@ -558,22 +558,20 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             }
             return false;
 
-/*        case TO(_COLEMAKDH):
-            if (record->event.pressed) {
-                gam_ent_on = true;
-            }
-            return true; // Let QMK handle the rest for TO(_COLEMAKDH)
-*/
+        
+
         case KC_ENTER:
-            if (gam_ent_on && record->event.pressed) {
+            if (gam_ent_on && record->event.pressed) { // Checks if GAM_ENT was pressed ingame
+                tap_code(KC_ENT);
                 gam_ent_on = false;
-                layer_invert(_GAMING); // Switch to GAMING layer
+                layer_invert(_GAMING); // Switches back to GAMING layer after chatting
             }
             return true; // Let QMK handle the rest
 
         case GAM_ENT:
             // Toggle `gam_ent_on`
             if (record->event.pressed) {
+                tap_code(KC_ENT);
                 layer_invert(_GAMING);
                 gam_ent_enable();               
             }

--- a/keymap.c
+++ b/keymap.c
@@ -1,5 +1,5 @@
 
- /* Copyright 2021 Dane Evans
+ /* Copyright 2021 Ryuuga W
   *
   * This program is free software: you can redistribute it and/or modify
   * it under the terms of the GNU General Public License as published by
@@ -24,10 +24,11 @@
 #define HSV_OVERRIDE_HELP(h, s, v, Override) h, s , Override
 #define HSV_OVERRIDE(hsv, Override) HSV_OVERRIDE_HELP(hsv,Override)
 
-// Light combinations
-// define SET_INDICATORS(hsv) \ //
-	 //{0, 1, HSV_OVERRIDE_HELP(hsv, INDICATOR_BRIGHTNESS)}, \//
-     //{35+0, 1, hsv}//
+/* Light combinations
+   define SET_INDICATORS(hsv) \ 
+	 {0, 1, HSV_OVERRIDE_HELP(hsv, INDICATOR_BRIGHTNESS)}, \
+     {35+0, 1, hsv}
+*/
 #define SET_UNDERGLOW(hsv) \
 	{0, 6, hsv}, \
     {35, 6, hsv}
@@ -67,8 +68,8 @@
       {50, 2, hsv}, \
       {60, 2, hsv}
 
-	// {0, 1, HSV_OVERRIDE_HELP(hsv, INDICATOR_BRIGHTNESS)}, \ //
-    // {35+0, 1, HSV_OVERRIDE_HELP(hsv, INDICATOR_BRIGHTNESS)}, \ // 
+	/* {0, 1, HSV_OVERRIDE_HELP(hsv, INDICATOR_BRIGHTNESS)}, \ 
+       {35+0, 1, HSV_OVERRIDE_HELP(hsv, INDICATOR_BRIGHTNESS)}, \ */ 
 
 
 
@@ -90,7 +91,7 @@ enum custom_keycodes {
     KC_ADJUST,
     KC_D_MUTE,
     KC_SWITCH, 
-    GAM_ENT
+    GAM_CHT
     
 };
 
@@ -109,9 +110,9 @@ enum {
 #define TD_LANG KC_GRV
 #endif
 
-bool gam_ent_on;
-void gam_ent_enable(void);
-void gam_ent_disable(void);
+bool game_chat_set;
+void game_chat_enable(void);
+void game_chat_disable(void);
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
@@ -170,7 +171,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   //|------+-------+--------+--------+--------+------|  ===  |   |  ===  |--------+-------+--------+--------+--------+---------| 
   KC_LALT  ,KC_B,   KC_Z,    KC_X,    KC_C,    KC_V,   XXXXXXX,   XXXXXXX,KC_N,    KC_M,   KC_COMM, KC_DOT,  KC_QUOT, KC_SLSH, \
   //|------+-------+--------+--------+--------+------|  ===  |   |  ===  |--------+-------+--------+--------+--------+---------| 
-                 XXXXXXX, KC_NUMPAD,KC_LCTRL, KC_SPC,  GAM_ENT,   KC_BSPC, KC_LSFT,  XXXXXXX,  KC_NAV, XXXXXXX \
+                 XXXXXXX, KC_NUMPAD,KC_LCTRL, KC_SPC,  GAM_CHT,   KC_BSPC, KC_LSFT,  XXXXXXX,  KC_NAV, XXXXXXX \
   //            \--------+--------+--------+---------+-------|   |--------+---------+--------+---------+-------/  
 ),
 
@@ -500,14 +501,14 @@ bool oled_task_user(void) {
 #endif
 
 
-// GAM_ENT: A key that taps enter to enable chat ingame, and temporarily toggles typing layer
+// GAM_CHT: A key that taps enter to enable chat ingame, and temporarily toggles typing layer
 // When you're done chatting, pressing enter to send will automatically swap back to game layer, no extra buttons needed
-void gam_ent_enable(void) {
-    gam_ent_on = true;
+void game_chat_enable(void) {
+    game_chat_set = true;
 }
 
-void gam_ent_disable(void) {
-    gam_ent_on = false;    
+void game_chat_disable(void) {
+    game_chat_set = false;    
 }
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
@@ -558,28 +559,28 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             }
             return false;
 
-        case KC_ESCAPE:   // Cancels chat mode in most games
-            if (gam_ent_on && record->event.pressed) { // Checks if GAM_ENT was pressed ingame
+        case KC_ESC:                                       // Cancels chat mode in most games
+            if (game_chat_set && record->event.pressed) {  // Checks if GAM_CHT was pressed ingame
                 tap_code(KC_ESC);
-                gam_ent_on = false;
-                layer_invert(_GAMING); // Switches back to GAMING layer after chatting
+                game_chat_set = false;
+                layer_invert(_GAMING);                     // Switches back to GAMING layer after chatting
             }
             return true; // Let QMK handle the rest
         
-        case KC_ENTER:
-            if (gam_ent_on && record->event.pressed) { // Checks if GAM_ENT was pressed ingame
+        case KC_ENT:
+            if (game_chat_set && record->event.pressed) {  // Checks if GAM_CHT was pressed ingame
                 tap_code(KC_ENT);
-                gam_ent_on = false;
-                layer_invert(_GAMING); // Switches back to GAMING layer after chatting
+                game_chat_set = false;
+                layer_invert(_GAMING);                     // Switches back to GAMING layer after chatting
             }
             return true; // Let QMK handle the rest
 
-        case GAM_ENT:
-            // Toggle `gam_ent_on`
+        case GAM_CHT:
+            // Toggle `game_chat_set`
             if (record->event.pressed) {
                 tap_code(KC_ENT);
                 layer_invert(_GAMING);
-                gam_ent_enable();               
+                game_chat_enable();               
             }
             return false;
 

--- a/keymap.c
+++ b/keymap.c
@@ -500,8 +500,8 @@ bool oled_task_user(void) {
 #endif
 
 
-// CAPS_WORD: A "smart" Caps Lock key that only capitalizes the next identifier you type
-// and then toggles off Caps Lock automatically when you're done.
+// GAM_ENT: A key that taps enter to enable chat ingame, and temporarily toggles typing layer
+// When you're done chatting, pressing enter to send will automatically swap back to game layer, no extra buttons needed
 void gam_ent_enable(void) {
     gam_ent_on = true;
 }
@@ -558,8 +558,14 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             }
             return false;
 
+        case KC_ESCAPE:   // Cancels chat mode in most games
+            if (gam_ent_on && record->event.pressed) { // Checks if GAM_ENT was pressed ingame
+                tap_code(KC_ESC);
+                gam_ent_on = false;
+                layer_invert(_GAMING); // Switches back to GAMING layer after chatting
+            }
+            return true; // Let QMK handle the rest
         
-
         case KC_ENTER:
             if (gam_ent_on && record->event.pressed) { // Checks if GAM_ENT was pressed ingame
                 tap_code(KC_ENT);

--- a/keymap.c
+++ b/keymap.c
@@ -504,47 +504,13 @@ bool oled_task_user(void) {
 // and then toggles off Caps Lock automatically when you're done.
 void gam_ent_enable(void) {
     gam_ent_on = true;
-    
 }
 
 void gam_ent_disable(void) {
-    gam_ent_on = false;
-    layer_invert(_GAMING);
-    
+    gam_ent_on = false;    
 }
-
-static void process_gam_ent(uint16_t keycode, const keyrecord_t *record) {
-    // Update caps word state
-    if (gam_ent_on) {
-
-        switch (keycode) {
-            // Keycodes to shift
-            case KC_A ... KC_Z:
-            case KC_MINS:
-            case KC_BSPC:
-            case KC_UNDS:
-            case KC_LPRN:
-            case KC_RPRN:
-                // When enter is pressed, returns to game layer
-                if (record->event.pressed) {
-                    tap_code(KC_ENT);
-                    gam_ent_disable();
-                }
-                break;
-        /*    default:
-                // Any other keycode should automatically return to game
-                if (record->event.pressed) {                
-                    gam_ent_disable();
-                }
-                break;*/
-        }
-    }
-}
-
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-        process_gam_ent(keycode, record);
-
 
     switch (keycode) {
          
@@ -592,23 +558,26 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             }
             return false;
 
+/*        case TO(_COLEMAKDH):
+            if (record->event.pressed) {
+                gam_ent_on = true;
+            }
+            return true; // Let QMK handle the rest for TO(_COLEMAKDH)
+*/
+        case KC_ENTER:
+            if (gam_ent_on && record->event.pressed) {
+                gam_ent_on = false;
+                layer_invert(_GAMING); // Switch to GAMING layer
+            }
+            return true; // Let QMK handle the rest
+
         case GAM_ENT:
             // Toggle `gam_ent_on`
             if (record->event.pressed) {
-                tap_code(KC_ENT);   
                 layer_invert(_GAMING);
-            
-            /*    if (gam_ent_on) {
-                    gam_ent_disable();
-                    return false;
-                } else {*/
-                    gam_ent_enable();
-            /*        return false;
-                }*/
-                
+                gam_ent_enable();               
             }
             return false;
-            break;
 
         case KC_D_MUTE:
             if (record->event.pressed) {


### PR DESCRIPTION
Your game layer is not your typing layer? Fret not! 

Enter GAM_CHT: A key that taps enter to enable chat in most online games, and then temporarily toggles your default typing layer.
When you're done chatting, pressing enter to send will automatically swap back to game layer, no extra buttons needed!! Additionally, pressing ESC will cancel chat mode in most games and will also return you to the GAME layer
